### PR TITLE
bug: use helm chart namespace when collecting resources

### DIFF
--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -21,6 +21,7 @@ var (
 	CleanMaps        = (*ResourceSummaryReconciler).cleanMaps
 	GetResources     = (*ResourceSummaryReconciler).getResources
 	GetHelmResources = (*ResourceSummaryReconciler).getHelmResources
+	GetChartResource = (*ResourceSummaryReconciler).getChartResource
 
 	GetKeyFromObject = getKeyFromObject
 )

--- a/controllers/resourcesummary_controller.go
+++ b/controllers/resourcesummary_controller.go
@@ -236,6 +236,22 @@ func (r *ResourceSummaryReconciler) getChartResource(helmResource *libsveltosv1a
 
 	copy(resources, helmResource.Resources)
 
+	// Helm Resources are taken by addon-controller from helm manifest
+	// and passed to drift-detection-manager. There are cases where
+	// namespace is not set even for namespace resources. See this
+	// for instance: https://github.com/projectsveltos/addon-controller/issues/363
+	// Instead of changing addon-controller which would require querying the
+	// api-server to understand if a resource is namespace or cluster wide,
+	// we add namespace here.
+	// From here on, returned slice will only be used in conjunction with
+	// dynamic.ResourceInterface which ignores namespace for cluster wide
+	// resources
+	for i := range resources {
+		if resources[i].Namespace == "" {
+			resources[i].Namespace = helmResource.ReleaseNamespace
+		}
+	}
+
 	return resources
 }
 


### PR DESCRIPTION
When a ClusterProfile is using configuration drift detection:

1. addon-controller gets list of deployed resources
2. passes this information in a ResourceSummary to drift-detection-manager
3. drift-detection-manager starts watching those resources and when it detects a configuration drift, drift-detection-manager reports it to management cluster causing a new reconciliation

With respect to Helm charts, addon-controller gets list of deployed resources using helm SDK and using manifest.
In certain scenarios, like this [one](https://github.com/projectsveltos/addon-controller/issues/363) manifest does not contain namespace for namespace resources like deployments.

If namespace is not set for namespace resource, point #3 won't work.

This PR fixes that. When drift-detection-manager gets resources deployed by addon-controller because of an Helm chart, it adds the helm chart namespace. This information is later on processed with dynamic.ResourceInterface which ignores namespace for cluster wide.