### PR TITLE
Hash evaluation: use dump.ForHash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: projectsveltos/drift-detection-manager-amd64:main
+      - image: projectsveltos/drift-detection-manager-amd64:dev
         name: manager

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -158,7 +158,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: projectsveltos/drift-detection-manager-amd64:main
+        image: projectsveltos/drift-detection-manager-amd64:dev
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifest/mgmt_cluster_manifest.yaml
+++ b/manifest/mgmt_cluster_manifest.yaml
@@ -45,7 +45,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: projectsveltos/drift-detection-manager-amd64:main
+        image: projectsveltos/drift-detection-manager-amd64:dev
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Previously code used to incorrectly think a configuration drift happened because of the way has was evaluated.