### PR TITLE
(bug): update image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ARCH ?= $(shell go env GOARCH)
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen
@@ -241,7 +241,7 @@ undeploy: $(CONTROLLER_GEN) $(KUSTOMIZE) ## Undeploy controller from the K8s clu
 set-manifest-image:
 	$(info Updating kustomize image patch file for manager resource)
 	sed -i'' -e 's@image: .*@image: '"docker.io/${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./config/default/manager_image_patch.yaml
-	sed -i'' -e 's@image: projectsveltos.*@image: '"docker.io/${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./manifest/mgmt_cluster_manifest.yaml
+	sed -i'' -e 's@image: .*@image: '"docker.io/${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./manifest/mgmt_cluster_manifest.yaml
 
 set-manifest-pull-policy:
 	$(info Updating kustomize pull policy file for manager resource)

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/drift-detection-manager:main
+      - image: docker.io/projectsveltos/drift-detection-manager:dev
         name: manager

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -112,7 +112,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager:main
+        image: docker.io/projectsveltos/drift-detection-manager:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/mgmt_cluster_manifest.yaml
+++ b/manifest/mgmt_cluster_manifest.yaml
@@ -28,7 +28,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager:main
+        image: docker.io/projectsveltos/drift-detection-manager:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
`make manifests` target now correctly updates the image tag for the drift-detection-manager when deployed in the management cluster

Closes #234 