### PR TITLE
(feat) drift-detection-manager compatibility check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,8 @@ bin/manager
 
 manager_image_patch.yaml-e
 manager_pull_policy.yaml-e
+manager_auth_proxy_patch.yaml-e
 mgmt_cluster_manifest.yaml-e
-
 
 version.txt
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ARCH ?= $(shell go env GOARCH)
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen
@@ -242,6 +242,8 @@ set-manifest-image:
 	$(info Updating kustomize image patch file for manager resource)
 	sed -i'' -e 's@image: .*@image: '"docker.io/${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./config/default/manager_image_patch.yaml
 	sed -i'' -e 's@image: .*@image: '"docker.io/${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./manifest/mgmt_cluster_manifest.yaml
+	sed -i'' -e 's@--version=.*@--version=$(TAG)"@' ./config/default/manager_auth_proxy_patch.yaml
+	sed -i'' -e 's@--version=.*@--version=$(TAG)@' ./manifest/mgmt_cluster_manifest.yaml
 
 set-manifest-pull-policy:
 	$(info Updating kustomize pull policy file for manager resource)

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -18,3 +18,4 @@ spec:
         - "--cluster-type="
         - "--current-cluster=managed-cluster"
         - "--run-mode=do-not-send-updates"
+        - "--version=dev"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/drift-detection-manager:main
+      - image: docker.io/projectsveltos/drift-detection-manager:dev
         name: manager

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,16 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - '*'
   resources:
   - '*'

--- a/controllers/resourcesummary_controller_test.go
+++ b/controllers/resourcesummary_controller_test.go
@@ -179,7 +179,8 @@ var _ = Describe("ResourceSummary Reconciler", func() {
 
 		// Manager initialization is done within SetupManager. So test calls it directly here.
 		Expect(driftdetection.InitializeManager(watcherCtx, logger, testEnv.Config, testEnv.Client, scheme,
-			randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout, false)).To(Succeed())
+			randomString(), randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout,
+			false)).To(Succeed())
 
 		Expect(controllers.UpdateMapsAndResourceSummaryStatus(reconciler, context.TODO(), resourceSummary, logger)).To(Succeed())
 

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -25,6 +25,7 @@ import (
 
 //+kubebuilder:rbac:groups=lib.projectsveltos.io,resources=debuggingconfigurations,verbs=get;list;watch
 //+kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update
 
 func InitScheme() (*runtime.Scheme, error) {
 	s := runtime.NewScheme()

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.37.1-0.20240831173303-3b450159d14f
+	github.com/projectsveltos/libsveltos v0.37.1-0.20240904135406-8f573456bb10
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.31.0
 	k8s.io/apiextensions-apiserver v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/projectsveltos/libsveltos v0.37.1-0.20240831173303-3b450159d14f h1:eeVqeBF8YJsf42bMhxQlHyQuV5GYBc1UrV9DMiAh588=
-github.com/projectsveltos/libsveltos v0.37.1-0.20240831173303-3b450159d14f/go.mod h1:YZQWtvZUDfg2VbjrPEGVQZa/yxq0n+KMV58iro7L5yg=
+github.com/projectsveltos/libsveltos v0.37.1-0.20240904135406-8f573456bb10 h1:54IvFGpL8g4tYbFXr/C+XZ3F2whmGoWVzfZBiNqH6C0=
+github.com/projectsveltos/libsveltos v0.37.1-0.20240904135406-8f573456bb10/go.mod h1:YZQWtvZUDfg2VbjrPEGVQZa/yxq0n+KMV58iro7L5yg=
 github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=
 github.com/prometheus/client_golang v1.19.1/go.mod h1:mP78NwGzrVks5S2H6ab8+ZZGJLZUq1hoULYBAYBw1Ho=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ var (
 	webhookPort         int
 	syncPeriod          time.Duration
 	healthAddr          string
+	version             string
 )
 
 // Add RBAC for the authorized diagnostics endpoint.
@@ -174,41 +175,22 @@ func initFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&insecureDiagnostics, "insecure-diagnostics", false,
 		"Enable insecure diagnostics serving. For more details see the description of --diagnostics-address.")
 
-	flag.StringVar(
-		&runMode,
-		"run-mode",
-		noUpdates,
+	flag.StringVar(&runMode, "run-mode", noUpdates,
 		"indicates whether updates will be sent to management cluster or just created locally",
 	)
 
-	flag.StringVar(
-		&deployedCluster,
-		"current-cluster",
-		managedCluster,
+	flag.StringVar(&deployedCluster, "current-cluster", managedCluster,
 		"Indicate whether drift-detection-manager was deployed in the managed or the management cluster. "+
 			"Possible options are managed-cluster or management-cluster.",
 	)
 
-	flag.StringVar(
-		&clusterNamespace,
-		"cluster-namespace",
-		"",
-		"cluster namespace",
-	)
+	flag.StringVar(&clusterNamespace, "cluster-namespace", "", "cluster namespace")
 
-	flag.StringVar(
-		&clusterName,
-		"cluster-name",
-		"",
-		"cluster name",
-	)
+	flag.StringVar(&clusterName, "cluster-name", "", "cluster name")
 
-	flag.StringVar(
-		&clusterType,
-		"cluster-type",
-		"",
-		"cluster type",
-	)
+	flag.StringVar(&clusterType, "cluster-type", "", "cluster type")
+
+	flag.StringVar(&version, "version", "", "indicates sveltos-agent version")
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
@@ -254,10 +236,10 @@ func initializeManager(ctx context.Context, mgr ctrl.Manager, sendUpdates contro
 		var err error
 		if sendUpdates == controllers.SendUpdates {
 			err = driftdetection.InitializeManager(ctx, mgr.GetLogger(), mgr.GetConfig(), mgr.GetClient(), mgr.GetScheme(),
-				clusterNamespace, clusterName, clusterType, intervalInSecond, true)
+				clusterNamespace, clusterName, version, clusterType, intervalInSecond, true)
 		} else {
 			err = driftdetection.InitializeManager(ctx, mgr.GetLogger(), mgr.GetConfig(), mgr.GetClient(), mgr.GetScheme(),
-				clusterNamespace, clusterName, clusterType, intervalInSecond, false)
+				clusterNamespace, clusterName, version, clusterType, intervalInSecond, false)
 		}
 
 		if err != nil {

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -15,6 +15,16 @@ metadata:
   name: drift-detection-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - '*'
   resources:
   - '*'
@@ -110,9 +120,10 @@ spec:
         - --cluster-type=
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-updates
+        - --version=dev
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager:main
+        image: docker.io/projectsveltos/drift-detection-manager:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/mgmt_cluster_manifest.yaml
+++ b/manifest/mgmt_cluster_manifest.yaml
@@ -26,9 +26,10 @@ spec:
         - --cluster-type=
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-updates
+        - --version=dev
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager:main
+        image: docker.io/projectsveltos/drift-detection-manager:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift_evaluation_test.go
+++ b/pkg/drift-detection/drift_evaluation_test.go
@@ -83,7 +83,8 @@ var _ = Describe("Manager: drift evaluation", func() {
 		logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
 
 		Expect(driftdetection.InitializeManager(watcherCtx, logger, testEnv.Config, testEnv.Client, scheme,
-			randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout, false)).To(Succeed())
+			randomString(), randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout,
+			false)).To(Succeed())
 		manager, err := driftdetection.GetManager()
 		Expect(err).To(BeNil())
 
@@ -197,7 +198,8 @@ var _ = Describe("Manager: drift evaluation", func() {
 		logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
 
 		Expect(driftdetection.InitializeManager(watcherCtx, logger, testEnv.Config, testEnv.Client, scheme,
-			randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout, false)).To(Succeed())
+			randomString(), randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout,
+			false)).To(Succeed())
 		manager, err := driftdetection.GetManager()
 		Expect(err).To(BeNil())
 
@@ -264,7 +266,8 @@ var _ = Describe("Manager: drift evaluation", func() {
 		logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
 
 		Expect(driftdetection.InitializeManager(watcherCtx, logger, testEnv.Config, testEnv.Client, scheme,
-			randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout, false)).To(Succeed())
+			randomString(), randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout,
+			false)).To(Succeed())
 		manager, err := driftdetection.GetManager()
 		Expect(err).To(BeNil())
 

--- a/pkg/drift-detection/manager.go
+++ b/pkg/drift-detection/manager.go
@@ -114,7 +114,7 @@ type manager struct {
 
 // InitializeManager initializes a manager
 func InitializeManager(ctx context.Context, l logr.Logger, config *rest.Config, c client.Client,
-	scheme *runtime.Scheme, clusterNamespace, clusterName string, cluserType libsveltosv1beta1.ClusterType,
+	scheme *runtime.Scheme, clusterNamespace, clusterName, version string, cluserType libsveltosv1beta1.ClusterType,
 	intervalInSecond uint, sendUpdates bool) error {
 
 	if managerInstance == nil {
@@ -147,7 +147,12 @@ func InitializeManager(ctx context.Context, l logr.Logger, config *rest.Config, 
 				return err
 			}
 
-			go managerInstance.evaluateConfigurationDrift(ctx)
+			var wg sync.WaitGroup
+
+			go managerInstance.evaluateConfigurationDrift(ctx, &wg)
+			wg.Add(1)
+
+			go managerInstance.storeVersionForCompatibilityChecks(ctx, version, &wg)
 		}
 	}
 

--- a/pkg/drift-detection/manager_test.go
+++ b/pkg/drift-detection/manager_test.go
@@ -63,7 +63,8 @@ var _ = Describe("Manager: registration", func() {
 		Expect(addTypeInformationToObject(scheme, &resource)).To(Succeed())
 
 		Expect(driftdetection.InitializeManager(watcherCtx, logger, testEnv.Config, testEnv.Client, scheme,
-			randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout, false)).To(Succeed())
+			randomString(), randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout,
+			false)).To(Succeed())
 		manager, err := driftdetection.GetManager()
 		Expect(err).To(BeNil())
 
@@ -127,7 +128,8 @@ var _ = Describe("Manager: registration", func() {
 
 	It("readResourceSummaries processes all existing ResourceSummaries", func() {
 		Expect(driftdetection.InitializeManager(watcherCtx, logger, testEnv.Config, testEnv.Client, scheme,
-			randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout, false)).To(Succeed())
+			randomString(), randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout,
+			false)).To(Succeed())
 		manager, err := driftdetection.GetManager()
 		Expect(err).To(BeNil())
 

--- a/pkg/drift-detection/watcher_test.go
+++ b/pkg/drift-detection/watcher_test.go
@@ -56,7 +56,8 @@ var _ = Describe("Manager: react", func() {
 
 	It("react: queue resource to be evaluated for configuration drift", func() {
 		Expect(driftdetection.InitializeManager(watcherCtx, logger, testEnv.Config, testEnv.Client, scheme,
-			randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout, false)).To(Succeed())
+			randomString(), randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, evaluateTimeout,
+			false)).To(Succeed())
 		manager, err := driftdetection.GetManager()
 		Expect(err).To(BeNil())
 

--- a/test/fv/fv_suite_test.go
+++ b/test/fv/fv_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fv_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -26,8 +27,11 @@ import (
 
 	"github.com/TwiN/go-color"
 	ginkgotypes "github.com/onsi/ginkgo/v2/types"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-api/util"
@@ -89,6 +93,21 @@ var _ = BeforeSuite(func() {
 	var err error
 	k8sClient, err = client.New(restConfig, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
+
+	By("Verifying ConfigMap with version for compatibility checks is created")
+	Eventually(func() bool {
+		cm := &corev1.ConfigMap{}
+		err := k8sClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: "projectsveltos", Name: "drift-detection-version"},
+			cm)
+		if err != nil {
+			return apierrors.IsNotFound(err)
+		}
+		if cm.Data == nil {
+			return false
+		}
+		return cm.Data["version"] != ""
+	}, timeout, pollingInterval).Should(BeTrue())
 })
 
 func randomString() string {


### PR DESCRIPTION
drift-detection-manager evaluates resourceSummary instances within each managed cluster to detect other configuration drift. Other Sveltos microservices (addon-controller) in the management cluster consume these evaluation results. During upgrades, management cluster services should pause fetching drift-detection evaluation results until the drift-detection version aligns with the versions of the Sveltos microservices in the management cluster.

Drift-detection creates a ConfigMap in each managed cluster to store its version. Sveltos services in the management cluster then reference this ConfigMap to verify version compatibility.

This compatibility check is especially important when Sveltos CRD versions change after upgrades. For example, if we transition from v1alpha1 to v1beta1, without this check, Sveltos microservices might attempt to fetch v1beta1 instances while sveltos-agent and the CRDs in the managed cluster are still on the older version.

This PR makes sure that drift-detection stores its current version after successfully evaluating resourceSummary once.